### PR TITLE
upgrading version on jupyterhub to solve vulnerabilities

### DIFF
--- a/docker/jupyterhub/Dockerfile
+++ b/docker/jupyterhub/Dockerfile
@@ -1,6 +1,6 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
-FROM jupyterhub/jupyterhub:2.2.2
+FROM jupyterhub/jupyterhub:2.3.1
 
 # Installing sssd-tools (required for authentication)
 RUN apt-get update -qq && \


### PR DESCRIPTION
Prøver å endre versjon av jupyterhub i håp om at det løser sårbarhetene fra versjon 2.2.2