### PR TITLE
Kernel environment bugfix

### DIFF
--- a/docker/jupyterlab/bashrc.felles
+++ b/docker/jupyterlab/bashrc.felles
@@ -6,6 +6,9 @@ source /etc/profile.d/stamme_variabel
 # Set FELLES environment variable
 export FELLES=/ssb/bruker/felles
 
+# Adding pythonForSsb in PYTHONPATH
+export PYTHONPATH=$PYTHONPATH:/ssb/bruker/felles/pythonForSsb
+
 # Setting up environment variables for pip and pipenv
 # Pip config so users install from Nexus.
 export PIP_INDEX=http://pl-nexuspro-p.ssb.no:8081/repository/pypi-proxy/pypi

--- a/docker/jupyterlab/kernels/ir/r.sh
+++ b/docker/jupyterlab/kernels/ir/r.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 
-# setup environment variable, etc.
-if [ "$INGEN_STAMMER_TAKK" == "" ]; then
-        source /etc/profile.d/stamme_variabel
-fi
+# setup user defined environment variables
+# .bashrc also calls bashrc.felles
+source $HOME/.bashrc
 
-export FELLES="/ssb/bruker/felles"
 export R_PROFILE_USER="/opt/conda/share/jupyter/kernels/ir/Rstartup"
 export R_LIBS_USER="/usr/lib/R/library"
 

--- a/docker/jupyterlab/kernels/python3/python.sh
+++ b/docker/jupyterlab/kernels/python3/python.sh
@@ -1,8 +1,7 @@
 #!/usr/bin/env bash
 
-source /etc/profile.d/stamme_variabel
-
-export FELLES=/ssb/bruker/felles
-export PYTHONPATH=$PYTHONPATH:/ssb/bruker/felles/pythonForSsb
+# setup user defined environment variables
+# .bashrc also calls bashrc.felles
+source $HOME/.bashrc
 
 exec /opt/conda/bin/python -m ipykernel $@


### PR DESCRIPTION
Øyvind found a bug where oracle environment variables are not available in the kernels. I recently moved all environment variables from before-notebook.d/env.sh to bashrc.felles, and bashrc.felles is sourced from .bashrc. Therefore sourcing .bashrc at kernel-start ensures all the set environment variables exist for the kernels. This fix also allows user-defined environment variables in .bashrc to be sourced and available to the kernel.