### PR TITLE
Use proxy for https connections

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -80,4 +80,7 @@ RUN ln -s /usr/local/bin/python-env.bash /usr/local/bin/python-env
 # User will not be able to install packages outside of a virtual environment
 ENV PIP_REQUIRE_VIRTUALENV=true
 
+# Use proxy for https connections
+ENV https_proxy=http://proxy.ssb.no:3128
+
 USER $NB_UID


### PR DESCRIPTION
This PR adds the `https_proxy` environment variable, which will redirect https calls through SSB's proxy. This enables the `ssb-project-cli` to call the github API via https.