### PR TITLE
Add statbank authenticator to docker compose

### DIFF
--- a/docker/jupyterhub/.env
+++ b/docker/jupyterhub/.env
@@ -1,2 +1,3 @@
 DOCKER_NOTEBOOK_IMAGE=nexus.ssb.no:8437/prod-bip/ssb/statistikktjenester/jupyterlab-onprem:latest
 DOCKER_HUB_IMAGE=nexus.ssb.no:8437/prod-bip/ssb/statistikktjenester/jupyterhub-onprem:latest
+STATBANK_AUTHENTICATOR_IMAGE=nexus.ssb.no:8437/prod-bip/ssb/dapla/dapla-statbank-authenticator:latest

--- a/docker/jupyterhub/.env
+++ b/docker/jupyterhub/.env
@@ -1,3 +1,3 @@
 DOCKER_NOTEBOOK_IMAGE=nexus.ssb.no:8437/prod-bip/ssb/statistikktjenester/jupyterlab-onprem:latest
 DOCKER_HUB_IMAGE=nexus.ssb.no:8437/prod-bip/ssb/statistikktjenester/jupyterhub-onprem:latest
-STATBANK_AUTHENTICATOR_IMAGE=nexus.ssb.no:8437/prod-bip/ssb/dapla/dapla-statbank-authenticator:latest
+STATBANK_AUTHENTICATOR_IMAGE=nexus.ssb.no:8437/prod-bip/ssb/dapla/dapla-statbank-authenticator:0.1.1

--- a/docker/jupyterhub/docker-compose.yml
+++ b/docker/jupyterhub/docker-compose.yml
@@ -51,10 +51,22 @@ services:
       # Postgres db info
       POSTGRES_DB: jupyterhub
       POSTGRES_HOST: hub-db
+      # Should be passed on to jupyterlab instances
+      STATBANK_ENCRYPT_URL: http://statbank-authenticator/encrypt
     env_file:
       - ~/secrets/postgres/postgres.env
     command: >
       jupyterhub -f /srv/jupyterhub/jupyterhub_config.py
+
+  statbank-authenticator:
+    image: ${STATBANK_AUTHENTICATOR_IMAGE}
+    container_name: statbank-authenticator
+    restart: always
+    ports:
+      - "80:8080"
+    env_file:
+      - ~/secrets/statbank-authenticator/statbank.env
+
 volumes:
   data:
     external:

--- a/docker/jupyterhub/jupyterhub_config.py
+++ b/docker/jupyterhub/jupyterhub_config.py
@@ -102,3 +102,7 @@ c.JupyterHub.db_url = "postgresql://postgres:{password}@{host}/{db}".format(
     password=os.environ["POSTGRES_PASSWORD"],
     db=os.environ["POSTGRES_DB"],
 )
+
+c.DockerSpawner.environment = {
+    "STATBANK_AUTHENTICATOR_IMAGE": os.environ["STATBANK_AUTHENTICATOR_IMAGE"]
+}


### PR DESCRIPTION
Waiting for nexus to be synced with `eu.gcr.io/prod-bip/ssb/dapla/dapla-statbank-authenticator`