### PR TITLE
new r repo should now be added automatically after renv::init()

### DIFF
--- a/docker/jupyterlab/Rprofile.site
+++ b/docker/jupyterlab/Rprofile.site
@@ -1,6 +1,8 @@
 # Setting default repo globally
-local({
-    r <- getOption("repos")
-    r["CRAN"] <- "https://nexus.ssb.no/repository/packagemanager-rstudio/"
-    options(repos = r)
-})
+home <- Sys.getenv("R_HOME")
+.libPaths(c(file.path(home, "lib"), .libPaths()))
+
+r <- getOption("repos")
+r["CRAN"] <- "https://nexus.ssb.no/repository/packagemanager-rstudio/"
+options(repos = r)
+rm(r)


### PR DESCRIPTION
While #45 fixed installing r packages from packagemanager-rstudio outside of a virtual environment, it did not fix inside of one. I have tested the new solution multiple times and it seems to work with this change.