### PR TITLE
added github to no_proxy

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -94,7 +94,7 @@ RUN pip config set global.index http://pl-nexuspro-p.ssb.no:8081/repository/pypi
 
 # Use proxy for https connections
 ENV https_proxy=http://proxy.ssb.no:3128
-ENV no_proxy=nexus.ssb.no,git-adm.ssb.no,i.test.ssb.no,i.ssb.no
+ENV no_proxy=nexus.ssb.no,git-adm.ssb.no,i.test.ssb.no,i.ssb.no,github.com,api.github.com,codeload.github.com
 
 # Set FELLES environment variable
 ENV FELLES=/ssb/bruker/felles


### PR DESCRIPTION
access to github.com/statisticsnorway, api.github.com/repos/statisticsnorway and codeload.github.com/statisticsnorway has been added to the firewall. As such we update no_proxy to exclude the urls from proxy