### PR TITLE
We cannot read .env from outside compose's cwd

### DIFF
--- a/docker/jupyterhub/docker-compose.yml
+++ b/docker/jupyterhub/docker-compose.yml
@@ -56,7 +56,6 @@ services:
       STATBANK_BASE_URL: ${STATBANK_BASE_URL}
       JUPYTERHUB_HTTP_REFERER: ${JUPYTERHUB_HTTP_REFERER}
     env_file:
-      - ~/secrets/compose/.env
       - ~/secrets/postgres/postgres.env
     command: >
       jupyterhub -f /srv/jupyterhub/jupyterhub_config.py

--- a/docker/jupyterhub/jupyterhub.service
+++ b/docker/jupyterhub/jupyterhub.service
@@ -8,7 +8,7 @@ Type=oneshot
 RemainAfterExit=true
 User=jupyterhub
 WorkingDirectory=/home/jupyterhub/jupyterhub-onprem/docker/jupyterhub
-ExecStart=/usr/local/bin/docker-compose -f docker-compose.yml up -d
+ExecStart=/usr/local/bin/docker-compose -f docker-compose.yml --env-file /home/jupyterhub/secrets/compose/.env up -d
 ExecStop=/usr/local/bin/docker-compose -f docker-compose.yml stop
 
 [Install]


### PR DESCRIPTION
Added --env-file to service file that starts docker-compose, this way env vars is read from ~/secrets/compose/.env