### PR TITLE
Correct release tag

### DIFF
--- a/.github/workflows/jupyterhub-docker-build-and-deploy.yml
+++ b/.github/workflows/jupyterhub-docker-build-and-deploy.yml
@@ -29,7 +29,7 @@ jobs:
       id-token: "write"
     runs-on: ubuntu-latest
     outputs:
-      semver_image_tag: v${{ steps.metadata.outputs.version }}
+      semver_image_tag: ${{ steps.metadata.outputs.version }}
     steps:
       - name: "Check out repo"
         uses: actions/checkout@v3

--- a/.github/workflows/jupyterlab-docker-build-and-deploy.yml
+++ b/.github/workflows/jupyterlab-docker-build-and-deploy.yml
@@ -29,7 +29,7 @@ jobs:
       id-token: "write"
     runs-on: ubuntu-latest
     outputs:
-      semver_image_tag: v${{ steps.metadata.outputs.version }}
+      semver_image_tag: ${{ steps.metadata.outputs.version }}
     steps:
       - name: "Check out repo"
         uses: actions/checkout@v3


### PR DESCRIPTION
The `v` was doubled, see screenshot.

![Screenshot 2023-11-14 at 09 16 06](https://github.com/statisticsnorway/jupyterhub-onprem/assets/42948872/d684b752-f9b7-46ca-a772-0eee34ae5f0a)
