### PR TITLE
Change Poetry to use the system git client

### DIFF
--- a/docker/jupyterhub/.env.prod
+++ b/docker/jupyterhub/.env.prod
@@ -3,3 +3,5 @@ DOCKER_HUB_IMAGE=nexus.ssb.no:8439/artifact-registry-5n/dapla-stat-docker/jupyte
 STATBANK_AUTHENTICATOR_IMAGE=nexus.ssb.no:8437/prod-bip/ssb/dapla/dapla-statbank-authenticator:0.1.6
 STATBANK_BASE_URL=https://i.ssb.no/
 JUPYTERHUB_HTTP_REFERER=https://sl-jupyter-p.ssb.no/
+POETRY_EXPERIMENTAL_SYSTEM_GIT_CLIENT=true # Needs to be enabled until this issue is fixed
+                                           # https://github.com/jelmer/dulwich/issues/1227

--- a/docker/jupyterhub/.env.staging
+++ b/docker/jupyterhub/.env.staging
@@ -3,3 +3,5 @@ DOCKER_HUB_IMAGE=nexus.ssb.no:8439/artifact-registry-5n/dapla-stat-docker/jupyte
 STATBANK_AUTHENTICATOR_IMAGE=nexus.ssb.no:8437/prod-bip/ssb/dapla/dapla-statbank-authenticator:latest
 STATBANK_BASE_URL=https://i.test.ssb.no/
 JUPYTERHUB_HTTP_REFERER=https://sl-jupyter-t.ssb.no/
+POETRY_EXPERIMENTAL_SYSTEM_GIT_CLIENT=true # Needs to be enabled until this issue is fixed
+                                           # https://github.com/jelmer/dulwich/issues/1227


### PR DESCRIPTION
Dulwich is now the default Git interface for Poetry. However, it does not populate `proxy_headers` correctly, which causes issues when using 1) Nexus mirrors and 2) Sourcing a Python package from GitHub.

We set an environment variable that causes the system git client to be used instead of Dulwich while this issue is resolved:
https://github.com/jelmer/dulwich/issues/1227