### PR TITLE
Disable prompt in apt-get

### DIFF
--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -22,7 +22,7 @@ RUN apt update && \
     # libaio required by oracle 64-bit client
     apt-get install -y libaio1 libaio-dev && \
     # STAT-569 - rJava issue onprem
-    apt-get install libbz2-dev && \
+    apt-get -y install libbz2-dev && \
     # Adding fonts required for tidyverse and other R dependencies
     apt-get install -y libfontconfig1-dev libfreetype6-dev libpng-dev libtiff5-dev libjpeg-dev libharfbuzz-dev libfribidi-dev && \
     apt autoremove -y && \

--- a/docker/jupyterlab/requirements.txt
+++ b/docker/jupyterlab/requirements.txt
@@ -1,5 +1,4 @@
 dapla-toolbelt==2.0.8
-ssb-datadoc==0.4.0
 ssb-project-cli==1.3.9
 dapla-team-cli==0.3.6
 kvakk-git-tools==2.2.2

--- a/docker/jupyterlab/requirements.txt
+++ b/docker/jupyterlab/requirements.txt
@@ -1,5 +1,5 @@
 dapla-toolbelt==2.0.8
-ssb-datadoc==0.6.0
+ssb-datadoc==0.4.0
 ssb-project-cli==1.3.9
 dapla-team-cli==0.3.6
 kvakk-git-tools==2.2.2


### PR DESCRIPTION
Add a `-y` flag to turn off interactive mode in installation. Remove `ssb-datadoc` as newer versions are incompatible with jupyterlab=3.6.6 (widgetsnbextension=4.0.5). The issue is reported here: https://github.com/statisticsnorway/datadoc/issues/205