### PR TITLE
Set fixed base image for jupyterlab and remove 'wheel' from admin_groups

### DIFF
--- a/docker/jupyterhub/jupyterhub_config.py
+++ b/docker/jupyterhub/jupyterhub_config.py
@@ -15,7 +15,7 @@ c.JupyterHub.spawner_class = "dockerspawner.SystemUserSpawner"
 c.PAMAuthenticator.pam_normalize_username = True
 
 # Add admin users
-c.PAMAuthenticator.admin_groups = {"wheel", "RBAG_jupyterhub_admins@ssb.no"}
+c.PAMAuthenticator.admin_groups = {"RBAG_jupyterhub_admins@ssb.no"}
 
 # Remove users that are no longer able to authenticate
 c.Authenticator.delete_invalid_users = True

--- a/docker/jupyterlab/Dockerfile
+++ b/docker/jupyterlab/Dockerfile
@@ -1,4 +1,5 @@
-ARG base_image="europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-stat-docker/jupyter/jupyterlab-common:latest"
+# Locking ourselves to this base_image to avoid breaking changes in the future
+ARG base_image="europe-north1-docker.pkg.dev/artifact-registry-5n/dapla-stat-docker/jupyter/jupyterlab-common:main-aedf4ed873bf739aa1f59890f301c528dd68e772"
 FROM ${base_image}
 
 USER root


### PR DESCRIPTION
- Set fixed base-image for jupyterlab so that we have control on the R version installed. If we don't have base_image lock, then the R version will update whenever the docker is rebuilt
- We remove `wheel` from `c.PAMAuthenticator.admin_groups = {"wheel", "RBAG_jupyterhub_admins@ssb.no"}`, because it is not required and is causing issues